### PR TITLE
Only require argparse for python < 2.7

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,3 +9,4 @@ v1.0.11, 2014.02.07 -- removed keyring as a dependency
 v1.0.12, 2014.02.07 -- minor bugfix
 v1.0.13, 2014.02.07 -- readme and example .gister updates
 v1.0.14, 2014.10.14 -- gister now accepts files as positional arguments for gisting
+v1.0.15, 2014.10.14 -- gister now requires argparse on python < 2.7

--- a/setup.py
+++ b/setup.py
@@ -14,17 +14,24 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+import sys
+
 from setuptools import setup, find_packages
+
+
+install_requires = ['requests']
+if sys.version_info < (2, 7):
+    install_requires.append('argparse')
 
 
 setup(
     name='gister',
-    version='1.0.14',
+    version='1.0.15',
     author='Trey Morris',
     author_email='trey@treymorris.com',
     description='gist making script',
     long_description=open('README.rst').read(),
-    install_requires=['argparse', 'requests'],
+    install_requires=install_requires,
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: Apache Software License'],
     keywords='github gist gists',


### PR DESCRIPTION
Fixes #8
