### PR TITLE
Add 'keyring' extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     description='gist making script',
     long_description=open('README.rst').read(),
     install_requires=install_requires,
+    extras_require=dict(keyring='keyring'),
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: Apache Software License'],
     keywords=['github', 'gist', 'gists'],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     description='gist making script',
     long_description=open('README.rst').read(),
     install_requires=install_requires,
-    extras_require=dict(keyring='keyring'),
+    extras_require=dict(keyring=['keyring']),
     classifiers=['Development Status :: 5 - Production/Stable',
                  'License :: OSI Approved :: Apache Software License'],
     keywords=['github', 'gist', 'gists'],


### PR DESCRIPTION
Among other things, this would allow me to `pipsi install gister[keyring]` and automatically get keyring support.